### PR TITLE
Normalize config paths to reduce warnings

### DIFF
--- a/Source/Gridly/Public/GridlyGameSettings.cpp
+++ b/Source/Gridly/Public/GridlyGameSettings.cpp
@@ -323,7 +323,7 @@ bool UGridlyGameSettings::DeserializeJsonToArray(const FString& JsonString, TArr
 
 FString UGridlyGameSettings::GetGridlyConfigPath()
 {
-    return FPaths::Combine(FPaths::ProjectConfigDir(), TEXT("GridlyConfig.ini"));
+    return FConfigCacheIni::NormalizeConfigIniPath(FPaths::Combine(FPaths::ProjectConfigDir(), TEXT("GridlyConfig.ini")));
 }
 
 void UGridlyGameSettings::EnsureConfigFileExists(const FString& ConfigPath)

--- a/Source/GridlyEditor/Private/GridlyImportExportCommandlet.cpp
+++ b/Source/GridlyEditor/Private/GridlyImportExportCommandlet.cpp
@@ -46,7 +46,7 @@ int32 UGridlyImportExportCommandlet::Main(const FString& Params)
 	FString ConfigPath;
 	if (const FString* ConfigParamVal = ParamVals.Find(FString(TEXT("Config"))))
 	{
-		ConfigPath = *ConfigParamVal;
+		ConfigPath = FConfigCacheIni::NormalizeConfigIniPath(*ConfigParamVal);;
 	}
 	else
 	{

--- a/Source/GridlyEditor/Private/GridlyLocalizedText.cpp
+++ b/Source/GridlyEditor/Private/GridlyLocalizedText.cpp
@@ -12,7 +12,7 @@
 bool FGridlyLocalizedText::GetAllTextAsPolyglotTextDatas(ULocalizationTarget* LocalizationTarget,
 	TArray<FPolyglotTextData>& OutPolyglotTextDatas, TSharedPtr<FLocTextHelper>& LocTextHelper)
 {
-	const FString ConfigFilePath = LocalizationConfigurationScript::GetGatherTextConfigPath(LocalizationTarget);
+	const FString ConfigFilePath = FConfigCacheIni::NormalizeConfigIniPath(LocalizationConfigurationScript::GetGatherTextConfigPath(LocalizationTarget));
 	const FString SectionName = TEXT("CommonSettings");
 
 	// Get native culture.


### PR DESCRIPTION
This fixes a lot of warnings that would appear when running Unreal Engine Commandlets and UAT commands:
`LogConfig: Warning: GConfig::Find attempting to access config with non-normalized path ../../Config/GridlyConfig.ini. Please use FConfigCacheIni::NormalizeConfigIniPath before accessing INI files through ConfigCache.`