### PR TITLE
Add files via upload

### DIFF
--- a/Source/GridlyEditor/Private/AssetTypeActions_GridlyDataTable.cpp
+++ b/Source/GridlyEditor/Private/AssetTypeActions_GridlyDataTable.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2021 LocalizeDirect AB
+// Copyright (c) 2021 LocalizeDirect AB
 
 #include "AssetTypeActions_GridlyDataTable.h"
 
@@ -32,7 +32,10 @@ public:
 	FGridlyDataTableCommands() :
 		TCommands<FGridlyDataTableCommands>("GridlyDataTableEditor",
 			NSLOCTEXT("Gridly", "GridlyDataTableEditor", "Gridly Data Table Editor"), NAME_None,
-			FEditorStyle::GetStyleSetName())
+// HS BEGIN: Fixed Warning
+//			FEditorStyle::GetStyleSetName())
+			FAppStyle::GetAppStyleSetName())
+// HS END
 	{
 	}
 
@@ -133,19 +136,34 @@ void FAssetTypeActions_GridlyDataTable::OpenAssetEditor(const TArray<UObject*>& 
 		DataTablesListText.Indent();
 		for (UDataTable* Table : InvalidDataTables)
 		{
-			const FName ResolvedRowStructName = Table->GetRowStructName();
+// HS BEGIN: Fixed Warning
+//			const FName ResolvedRowStructName = Table->GetRowStructName();
+//			DataTablesListText.AppendLineFormat(LOCTEXT("DataTable_MissingRowStructListEntry", "* {0} (Row Structure: {1})"),
+//				FText::FromString(Table->GetName()), FText::FromName(ResolvedRowStructName));
+			const FString ResolvedRowStructName = Table->GetRowStructPathName().ToString();
+
 			DataTablesListText.AppendLineFormat(LOCTEXT("DataTable_MissingRowStructListEntry", "* {0} (Row Structure: {1})"),
-				FText::FromString(Table->GetName()), FText::FromName(ResolvedRowStructName));
+				FText::FromString(Table->GetName()), FText::FromString(ResolvedRowStructName));
+// HS END
 		}
 
 		FText Title = LOCTEXT("DataTable_MissingRowStructTitle", "Continue?");
+// HS BEGIN: Fixed Warning
+// 		const EAppReturnType::Type DlgResult = FMessageDialog::Open(
+// 			EAppMsgType::YesNoCancel,
+// 			FText::Format(LOCTEXT("DataTable_MissingRowStructMsg",
+// 					"The following Data Tables are missing their row structure and will not be editable.\n\n{0}\n\nDo you want to open these data tables?"),
+// 				DataTablesListText.ToText()),
+// 			&Title
+// 			);
 		const EAppReturnType::Type DlgResult = FMessageDialog::Open(
 			EAppMsgType::YesNoCancel,
 			FText::Format(LOCTEXT("DataTable_MissingRowStructMsg",
-					"The following Data Tables are missing their row structure and will not be editable.\n\n{0}\n\nDo you want to open these data tables?"),
+				"The following Data Tables are missing their row structure and will not be editable.\n\n{0}\n\nDo you want to open these data tables?"),
 				DataTablesListText.ToText()),
-			&Title
-			);
+			Title
+// HS END
+		);
 
 		switch (DlgResult)
 		{
@@ -400,6 +418,7 @@ void FAssetTypeActions_GridlyDataTable::ExportToGridly(UGridlyDataTable* DataTab
 				             else
 				             {
 					             ExportDataTableToGridlySlowTask.Reset();
+								 this->ExportRequestQueue.Empty();
 					             const FString Content = HttpResponse->GetContentAsString();
 					             const FString ErrorReason =
 						             FString::Printf(TEXT("Error: %d, reason: %s"), HttpResponse->GetResponseCode(), *Content);


### PR DESCRIPTION
Fixed a lock up of the Editor if you and an error uploading to gridly using a GridlyDataTable that has more records than GetMutableDefault<UGridlyGameSettings>()->ExportMaxRecordsPerRequest (and so the request is split into multiple http requests).

References to the FScopedSlowTask are stored in the lambdas to the later http requests, but these are never triggered due to the error, so we need to clear out the export queue to clean up the references

I'm sorry this is showing up as a very big diff, it's acutally only a one line change in 421 :

 this->ExportRequestQueue.Empty();